### PR TITLE
use aliases instead

### DIFF
--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -85,6 +85,15 @@ const CONTENT_LABELS_PREFIXES = [
   ["tools", "DevTools"],
 ];
 
+const L10N_LABELS_PREFIXES = [
+  ["zh-cn", "zh"],
+  ["zh-tw", "zh"],
+  ["fr", "fr"],
+  ["ko", "ko"],
+  ["ja", "ja"],
+  ["pt-br", "pt-br"]
+];
+
 function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
   const baseURL = "https://github.com/mdn/content/issues/new";
   const sp = new URLSearchParams();
@@ -107,7 +116,8 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
       : doc.title;
   sp.set("title", `Issue with "${titleShort}": (short summary here please)`);
 
-  const slug = doc.mdn_url.split("/docs/")[1].toLowerCase();
+  const [lang, slug] = doc.mdn_url.toLowerCase().split("/docs/");
+  let labels = ["needs-triage"];
   let contentLabel = "";
   for (const [prefix, label] of CONTENT_LABELS_PREFIXES) {
     if (slug.startsWith(prefix)) {
@@ -118,7 +128,19 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
   if (!contentLabel) {
     contentLabel = "Other";
   }
-  sp.set("labels", `Content:${contentLabel},needs-triage`);
+  labels.push(`Content:${contentLabel}`);
+  let l10nLabel ;
+  for (const [prefix, label] of L10N_LABELS_PREFIXES) {
+    if (lang === prefix) {
+      l10nLabel = `l10n-${label}`;
+      break;
+    }
+  }
+  if (l10nLabel) {
+    labels.push(l10nLabel);
+  } // Maybe a l10n-unsupported label would be useful to add?
+
+  sp.set("labels", labels.join(','));
 
   const href = `${baseURL}?${sp.toString()}`;
 

--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -85,14 +85,13 @@ const CONTENT_LABELS_PREFIXES = [
   ["tools", "DevTools"],
 ];
 
-const L10N_LABELS_PREFIXES = [
+// For all locales that as spelled differently as a issue label, map the locale
+// to the proper label name. For locales not mentioned here, we keep the locale
+// as is.
+const LOCALE_LABEL_ALIASES = new Map([
   ["zh-cn", "zh"],
   ["zh-tw", "zh"],
-  ["fr", "fr"],
-  ["ko", "ko"],
-  ["ja", "ja"],
-  ["pt-br", "pt-br"]
-];
+]);
 
 function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
   const baseURL = "https://github.com/mdn/content/issues/new";
@@ -116,7 +115,9 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
       : doc.title;
   sp.set("title", `Issue with "${titleShort}": (short summary here please)`);
 
-  const [lang, slug] = doc.mdn_url.toLowerCase().split("/docs/");
+  const slug = doc.mdn_url.split("/docs/")[1].toLowerCase();
+  const { locale } = doc;
+
   let labels = ["needs-triage"];
   let contentLabel = "";
   for (const [prefix, label] of CONTENT_LABELS_PREFIXES) {
@@ -129,18 +130,14 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
     contentLabel = "Other";
   }
   labels.push(`Content:${contentLabel}`);
-  let l10nLabel ;
-  for (const [prefix, label] of L10N_LABELS_PREFIXES) {
-    if (lang === prefix) {
-      l10nLabel = `l10n-${label}`;
-      break;
-    }
+  if (locale !== "en-US") {
+    const localeLabel =
+      LOCALE_LABEL_ALIASES.get(locale.toLowerCase()) || locale.toLowerCase();
+    labels.push(`l10n-${localeLabel}`);
+    // Maybe a l10n-unsupported label would be useful to add?
   }
-  if (l10nLabel) {
-    labels.push(l10nLabel);
-  } // Maybe a l10n-unsupported label would be useful to add?
 
-  sp.set("labels", labels.join(','));
+  sp.set("labels", labels.join(","));
 
   const href = `${baseURL}?${sp.toString()}`;
 


### PR DESCRIPTION
Instead of posting comments about what I think we could improve, I wanted to test that my suggestions would make sense so I made a PR against your PR. 
Now things like http://localhost:3000/pt-BR/docs/Learn/JavaScript/First_steps/What_is_JavaScript#on-github and http://localhost:3000/zh-Cn/docs/Learn/JavaScript/First_steps/What_is_JavaScript#on-github work. 

E.g. 

- [pt-BR](https://github.com/mdn/content/issues/new?body=MDN+URL%3A+https%3A%2F%2Fdeveloper.mozilla.org%2Fpt-BR%2Fdocs%2FLearn%2FJavaScript%2FFirst_steps%2FWhat_is_JavaScript%0A%0A%23%23%23%23+What+information+was+incorrect%2C+unhelpful%2C+or+incomplete%3F%0A%0A%0A%23%23%23%23+Specific+section+or+headline%3F%0A%0A%0A%23%23%23%23+What+did+you+expect+to+see%3F%0A%0A%0A%23%23%23%23+Did+you+test+this%3F+If+so%2C+how%3F%0A%0A%0A%3C%21--+Do+not+make+changes+below+this+line+--%3E%0A%3Cdetails%3E%0A%3Csummary%3EMDN+Content+page+report+details%3C%2Fsummary%3E%0A%0A*+Folder%3A+%60pt-br%2Flearn%2Fjavascript%2Ffirst_steps%2Fwhat_is_javascript%60%0A*+MDN+URL%3A+https%3A%2F%2Fdeveloper.mozilla.org%2Fpt-BR%2Fdocs%2FLearn%2FJavaScript%2FFirst_steps%2FWhat_is_JavaScript%0A*+GitHub+URL%3A+https%3A%2F%2Fgithub.com%2Fmdn%2Ftranslated-content%2Fblob%2Fmain%2Ffiles%2Fpt-br%2Flearn%2Fjavascript%2Ffirst_steps%2Fwhat_is_javascript%2Findex.html%0A*+Last+commit%3A+https%3A%2F%2Fgithub.com%2Fmdn%2Ftranslated-content%2Fcommit%2Fe61e0fce63596bf8478914d291552758505ced04%0A*+Document+last+modified%3A+2021-07-04T21%3A28%3A21.000Z%0A%0A%3C%2Fdetails%3E&title=Issue+with+%22O+que+%C3%A9+JavaScript%3F%22%3A+%28short+summary+here+please%29&labels=needs-triage%2CContent%3ALearn%2Cl10n-pt-br)
- [zh-CN](https://github.com/mdn/content/issues/new?body=MDN+URL%3A+https%3A%2F%2Fdeveloper.mozilla.org%2Fzh-CN%2Fdocs%2FLearn%2FJavaScript%2FFirst_steps%2FWhat_is_JavaScript%0A%0A%23%23%23%23+What+information+was+incorrect%2C+unhelpful%2C+or+incomplete%3F%0A%0A%0A%23%23%23%23+Specific+section+or+headline%3F%0A%0A%0A%23%23%23%23+What+did+you+expect+to+see%3F%0A%0A%0A%23%23%23%23+Did+you+test+this%3F+If+so%2C+how%3F%0A%0A%0A%3C%21--+Do+not+make+changes+below+this+line+--%3E%0A%3Cdetails%3E%0A%3Csummary%3EMDN+Content+page+report+details%3C%2Fsummary%3E%0A%0A*+Folder%3A+%60zh-cn%2Flearn%2Fjavascript%2Ffirst_steps%2Fwhat_is_javascript%60%0A*+MDN+URL%3A+https%3A%2F%2Fdeveloper.mozilla.org%2Fzh-CN%2Fdocs%2FLearn%2FJavaScript%2FFirst_steps%2FWhat_is_JavaScript%0A*+GitHub+URL%3A+https%3A%2F%2Fgithub.com%2Fmdn%2Ftranslated-content%2Fblob%2Fmain%2Ffiles%2Fzh-cn%2Flearn%2Fjavascript%2Ffirst_steps%2Fwhat_is_javascript%2Findex.html%0A*+Last+commit%3A+https%3A%2F%2Fgithub.com%2Fmdn%2Ftranslated-content%2Fcommit%2F20ee8fa2eab15582db9c8e73094b60d548a5245e%0A*+Document+last+modified%3A+2021-06-16T18%3A54%3A07.000Z%0A%0A%3C%2Fdetails%3E&title=Issue+with+%22%E4%BB%80%E4%B9%88%E6%98%AF+JavaScript%EF%BC%9F%22%3A+%28short+summary+here+please%29&labels=needs-triage%2CContent%3ALearn%2Cl10n-zh)